### PR TITLE
correct package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   "devDependencies": {
     "babel-cli": "^6.7.5",
     "babel-core": "^6.7.6",
+    "babel-plugin-syntax-async-functions": "^6.8.0",
+    "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-es2015-node": "^5.0.3",
     "babel-preset-stage-0": "^6.5.0",


### PR DESCRIPTION
You should add "babel-plugin-transform-async-to-generator", "babel-plugin-syntax-async-functions" to "package.json" in order to make gulp works. Or you will get an error like this:

> [13:38:32] Using gulpfile ~/dev/ecma7-koa2-starter/gulpfile.js
> [13:38:32] Starting 'watch'...
> [13:38:32] Finished 'watch' after 25 ms
> [13:38:32] Starting 'default'...
> [13:38:32] Finished 'default' after 5.81 μs
> events.js:141
>      throw er; // Unhandled 'error' event
>      ^
> ReferenceError: Unknown plugin "transform-async-to-generator" 
